### PR TITLE
Allow Applecore to run in runClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 8fa7883b6196c1765266f4e6ddf3118d5043aafb
+//version: 1641429628
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -32,7 +32,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.4'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.5'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,15 @@ autoUpdateBuildScript = false
 minecraftVersion = 1.7.10
 forgeVersion = 10.13.4.1614
 
-# Select a username for testing your mod with breakpoints. You may leave this empty for a random user name each time you
+# Select a username for testing your mod with breakpoints. You may leave this empty for a random username each time you
 # restart Minecraft in development. Choose this dependent on your mod:
 # Do you need consistent player progressing (for example Thaumcraft)? -> Select a name
 # Do you need to test how your custom blocks interacts with a player that is not the owner? -> leave name empty
-developmentEnvironmentUserName = "Developer"
+developmentEnvironmentUserName = Developer
 
 # Define a source file of your project with:
 # public static final String VERSION = "GRADLETOKEN_VERSION";
-# The string's content will be replaced with your mods version when compiled. You should use this to specify your mod's
+# The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...])
 # Leave these properties empty to skip individual token replacements
 replaceGradleTokenInFile = ModInfo.java
@@ -32,7 +32,7 @@ gradleTokenModName =
 gradleTokenVersion = GRADLETOKEN_VERSION
 gradleTokenGroupName =
 
-# In case your mod provides an API for other mods to implement you may declare its package here. Otherwise you can
+# In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
 # Example value: apiPackage = api + modGroup = com.myname.mymodid -> com.myname.mymodid.api
 apiPackage = api
@@ -48,7 +48,7 @@ mixinPlugin = mixinplugin.MixinPlugin
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
 mixinsPackage = mixins
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
-# This parameter is for legacy compatability only
+# This parameter is for legacy compatibility only
 # Example value: coreModClass = asm.FMLPlugin + modGroup = com.myname.mymodid -> com.myname.mymodid.asm.FMLPlugin
 coreModClass =
 # If your project is only a consolidation of mixins or a core mod and does NOT contain a 'normal' mod ( = some class

--- a/src/main/java/squeek/applecore/mixinplugin/MixinPlugin.java
+++ b/src/main/java/squeek/applecore/mixinplugin/MixinPlugin.java
@@ -64,8 +64,9 @@ public class MixinPlugin implements IMixinConfigPlugin {
                 LOG.info("Found " + mod.modName + "! Integrating now...");
             }
             else {
-                LOG.error("Could not find " + mod.modName + "! Going to crash now");
-                FMLCommonHandler.instance().exitJava(-99, false);
+                LOG.error("Could not find " + mod.modName + "! Ought to crash now");
+                if (!isDevelopmentEnvironment)
+                    FMLCommonHandler.instance().exitJava(-99, false);
             }
         }
 


### PR DESCRIPTION
This will allow runClient to work when AppleCore is a dependency but without Pam's, etc. Still will crash out in production if the mixing fail.