### PR TITLE
Add "ExhaustFromHurt" Event

### DIFF
--- a/src/main/java/squeek/applecore/api/hunger/ExhaustionEvent.java
+++ b/src/main/java/squeek/applecore/api/hunger/ExhaustionEvent.java
@@ -1,6 +1,7 @@
 package squeek.applecore.api.hunger;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.FoodStats;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraftforge.common.MinecraftForge;
@@ -103,6 +104,35 @@ public abstract class ExhaustionEvent extends Event {
             boolean shouldDecreaseFoodLevel = !shouldDecreaseSaturationLevel && difficulty != EnumDifficulty.PEACEFUL;
 
             if (!shouldDecreaseFoodLevel) deltaHunger = 0;
+        }
+    }
+
+    /**
+     * Fired after post-damage mitigation calculations before applying it to health.
+     *
+     * This event is fired in {@link EntityPlayer#damageEntity} post damage mitigation before being applied to the
+     * player.<br>
+     * <br>
+     * This event is not fired if damage gets fully mitigated after armor, potion effects and absorption hearts.<br>
+     * <br>
+     * {@link #source} contains the source of the damage.<br>
+     * {@link #damage} contains the post-mitigation damage.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, it will skip exhausting the player.<br>
+     * <br>
+     * This event does not have a {@link Result}. {@link HasResult}<br>
+     */
+    @Cancelable
+    public static class ExhaustFromHurt extends ExhaustionEvent {
+
+        public DamageSource source;
+        public float damage;
+
+        public ExhaustFromHurt(EntityPlayer player, DamageSource source, float damage) {
+            super(player);
+            this.source = source;
+            this.damage = damage;
         }
     }
 }


### PR DESCRIPTION
A simple addition to the API capability:

Adds an additional Exhaustion Event that enables modifications to the hunger drain from taking damage to the health bar.

I need it for my upcoming nutrition mod and it is a very useful method, not just for food mods, but also for when you need to apply effects after post calculation damage but before that damage gets subtracted from the player health:
<img width="958" height="693" alt="image" src="https://github.com/user-attachments/assets/df5eb473-7409-4dec-b841-471a2ca4d5d5" />
